### PR TITLE
Cloudinary

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/app/views/participant_scores/index.html.erb
+++ b/app/views/participant_scores/index.html.erb
@@ -17,7 +17,7 @@
           <div class="trip-details">
             <div><h2 style="margin: 10px"><%= card[:ps].position %></h2></div>
             <!--TODO: add cloudinary image back in to card below-->
-            <!--div style="margin: 10px"> <%= cl_image_tag card[:ps].potential_destination.city.photo.key, height: 150, width: 200, crop: :fill %></div-->
+            <div style="margin: 10px"> <%= cl_image_tag card[:ps].potential_destination.city.photo.key, height: 150, width: 200, crop: :fill %></div>
             <div style="margin: 10px"><%= card[:ps].potential_destination.city.name %> suggested by <%= card[:ps].potential_destination.trip_participant.user.first_name %><br/>
               Time: <%= card[:te].flight_mins %><br/>
               Cost: £<%= (card[:te].low_cost + card[:te].high_cost)/2 %><br/>

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,14 @@
+$redis = Redis.new
+
+url = ENV["REDISCLOUD_URL"]
+
+if url
+  Sidekiq.configure_server do |config|
+    config.redis = { url: url }
+  end
+
+  Sidekiq.configure_client do |config|
+    config.redis = { url: url }
+  end
+  $redis = Redis.new(:url => url)
+end

--- a/db/migrate/20210312072548_add_admin_to_users.rb
+++ b/db/migrate/20210312072548_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_04_185831) do
+ActiveRecord::Schema.define(version: 2021_03_12_072548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,6 +137,7 @@ ActiveRecord::Schema.define(version: 2021_03_04_185831) do
     t.string "address_1"
     t.string "address_2"
     t.string "postcode"
+    t.boolean "admin", default: false, null: false
     t.index ["city_id"], name: "index_users_on_city_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
The Cloudinary error is caused by not running the AddPhotosJob.
That won't run without Sidekiq and Redis configured for Heroku.
We need admin to be set on users (migration)
This PR also adds the heroku configuration files
Once pushed to heroku, we need to run the following on CLI

heroku run rails db:migrate
<Then Set flags on user.admin to true>

heroku ps:scale worker=1
heroku ps # Check worker dyno is running

More details here: https://kitt.lewagon.com/camps/476/lectures/06-Projects%2F03-Advanced-Admin#source