### PR TITLE
added DatePreference.delete_all to seed due to foreignkey issue

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -310,6 +310,7 @@ end
 
 ParticipantScore.delete_all
 PotentialDestination.delete_all
+DatePreference.delete_all
 TripParticipant.delete_all
 Trip.delete_all
 TripEstimate.delete_all


### PR DESCRIPTION
db:seed was failing, because deleting TripParticipants without first deleting DatePreferences was being prevented by the DB