### PR TITLE
Add participant scores to seed

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -4,6 +4,7 @@ class Trip < ApplicationRecord
 
   has_many :trip_participants, dependent: :destroy
   has_many :users, through: :trip_participants
+  has_many :potential_destinations, through: :trip_participants
 
   validates :name, presence: true
 end

--- a/db/migrate/20210316211152_add_default_to_veto_in_participant_score.rb
+++ b/db/migrate/20210316211152_add_default_to_veto_in_participant_score.rb
@@ -1,0 +1,5 @@
+class AddDefaultToVetoInParticipantScore < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :participant_scores, :veto, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_14_184920) do
+ActiveRecord::Schema.define(version: 2021_03_16_211152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 2021_03_14_184920) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "position"
-    t.boolean "veto"
+    t.boolean "veto", default: false
     t.index ["potential_destination_id"], name: "index_participant_scores_on_potential_destination_id"
     t.index ["trip_participant_id"], name: "index_participant_scores_on_trip_participant_id"
   end


### PR DESCRIPTION
* Added `has_many :potential_destinations` relation to `Trip`
* Made `veto` value default to `false` [REQUIRES MIGRATION]
* Simplified `seed_potential_destinations` so each person picks one city (no duplicates)
* Added a method to seed participant scores (vetoes the very last participant score)