### PR TITLE
fixed border radius on completed trip photo on trip index page

### DIFF
--- a/app/assets/stylesheets/components/_tripcardimage.scss
+++ b/app/assets/stylesheets/components/_tripcardimage.scss
@@ -3,6 +3,7 @@
   background-size: cover;
   background-position: center;
   width: 100%;
+  border-radius: $border-radius $border-radius 0 0;
   // background-image: url('https://source.unsplash.com/random');
   // background-image: url('https://images.unsplash.com/photo-1534534573898-db5148bc8b0c?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=675&q=80');
 }


### PR DESCRIPTION
From this:

<img width="318" alt="image" src="https://user-images.githubusercontent.com/9137502/112719015-69018500-8eee-11eb-8808-c21873a06f84.png">

To this:

<img width="300" alt="image" src="https://user-images.githubusercontent.com/9137502/112719030-7b7bbe80-8eee-11eb-9edf-27ce7d61e92d.png">
